### PR TITLE
Exclude unused struct from generated binding

### DIFF
--- a/libfyaml-sys/build.rs
+++ b/libfyaml-sys/build.rs
@@ -30,6 +30,7 @@ fn main() {
         .allowlist_function("fy_.*")
         .allowlist_type("fy_.*")
         .blocklist_function("fy_library_version")
+        .blocklist_type("fy_node_mapping_sort_ctx")
         // Variadic functions that use `va_list`.
         // Blocked on https://github.com/rust-lang/rust/issues/44930.
         .blocklist_function("fy_diag_node_override_vreport")


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/125572, there is a new dead code warning in bindgen-generated code.

```console
warning: struct `fy_node_mapping_sort_ctx` is never constructed
   --> target/debug/build/libfyaml-sys-2dd5e4a2f30f795e/out/bindings.rs:129:12
    |
129 | pub struct fy_node_mapping_sort_ctx {
    |            ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default
```